### PR TITLE
Fix compilation errors on NixOS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678470307,
-        "narHash": "sha256-OEeMUr3ueLIXyW/OaFUX5jUdimyQwMg/7e+/Q0gC/QE=",
+        "lastModified": 1678654296,
+        "narHash": "sha256-aVfw3ThpY7vkUeF1rFy10NAkpKDS2imj3IakrzT0Occ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c4800d579af4ed98ecc47d464a5e7b0870c4b1f",
+        "rev": "5a1dc8acd977ff3dccd1328b7c4a6995429a656b",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1678532366,
-        "narHash": "sha256-eDjDixrhoGe2cbNGWt3SaSbjeohYbVKLtIWqSJ+wfGU=",
+        "lastModified": 1678713688,
+        "narHash": "sha256-V9cg59Rd+QOAc+iZhIDM/9PojhuzlzZHwkluZ5PJcds=",
         "owner": "alekseysidorov",
         "repo": "nixpkgs-cross-overlay",
-        "rev": "38dbd64a32e1e1abdb6e9454e5a8085c926a1054",
+        "rev": "1053a2847be858a06a5429b292278f73b19ad219",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678501303,
-        "narHash": "sha256-92s2NOlcvydz0Cxi1OOq/bs7SQc38TaqzuzdHsRANhA=",
+        "lastModified": 1678674283,
+        "narHash": "sha256-MnFqHP7AwvjK3VLRmDnzbJWSL8lbDrmYESjQDaRmAVo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1c8200cdc4c830d937fbf8b19e1f3e83daf3370a",
+        "rev": "f25d4bc2f6a0a3f9a2f15d3b9e3edb0ee5099a3d",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
 channel = "stable"
-targets = ["x86_64-unknown-linux-musl"]
-components = ["rust-src", "llvm-tools-preview"]
+components = ["rust-src", "llvm-tools"]

--- a/scripts/build_docker_image.sh
+++ b/scripts/build_docker_image.sh
@@ -5,5 +5,5 @@ NIX_CROSS_SYSTEM=${NIX_CROSS_SYSTEM:-'{ config = "x86_64-unknown-linux-musl"; is
 
 # Compile service
 nix-shell --pure --arg crossSystem "${NIX_CROSS_SYSTEM}" --run "cargo build --release"
-image_archive=$(nix-build ./shell.nix -A dockerImage --arg crossSystem "$NIX_CROSS_SYSTEM")
+image_archive=$(nix-build ./shell.nix --no-out-link -A dockerImage --arg crossSystem "$NIX_CROSS_SYSTEM")
 echo $image_archive

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -8,5 +8,7 @@ edition = "2021"
 [dependencies]
 axum = "0.6"
 rdkafka = { version = "0.29", features = ["cmake-build"] }
+reqwest = "0.11"
 rocksdb = "0.20"
+tempfile = "3.3"
 tokio = { version = "1.0", features = ["full"] }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -4,12 +4,19 @@ use axum::{response::Html, routing::get, Router};
 
 #[tokio::main]
 async fn main() {
+    println!("Checking that HTTPS is working...");
+    println!("-> GET https://google.com");
+    let response = reqwest::get("https://google.com").await.unwrap();
+    assert!(
+        response.status().is_success(),
+        "Unsuccessful HTTPS response"
+    );
+    println!("-> OK");
+
     // build our application with a route
     let app = Router::new().route("/", get(handler));
-
     // run it
     let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
-
     println!("listening on {addr}");
 
     axum::Server::bind(&addr)
@@ -19,5 +26,12 @@ async fn main() {
 }
 
 async fn handler() -> Html<&'static str> {
+    // Force binary to use symbols from the rdkafka and rocksdb libraries.
+    let _client = rdkafka::config::ClientConfig::new()
+        .create_native_config()
+        .unwrap();
+    let path = tempfile::tempdir().unwrap();
+    let _db = rocksdb::DB::open_default(&path).unwrap();
+
     Html("<h1>Hello, World!</h1>")
 }


### PR DESCRIPTION
These changes should fix the #2 issue

- Use `nativeBuildInputs` as runtime dependencies for the compiled Rust binary
- Fix cargoDeps packages target
- Force example service to use symbols from the compiled system libraries
- Add code to check that the HTTPS is working fine